### PR TITLE
style: harmonize profile card colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 2. Basic formatting with [Bootstrap](https://getbootstrap.com/)
 3. Publication visualization with [D3.js](https://d3js.org/)
 4. Icons by Font Awesome (no changes made, [see license](https://fontawesome.com/license))
+5. Warm color theme for profile card aligned with the publication plot
 
 ## Setup
 

--- a/assets/css/home_style.css
+++ b/assets/css/home_style.css
@@ -1,18 +1,43 @@
-
 svg {
-    width: 100%;
-    height: 100vh;
+  width: 100%;
+  height: 100vh;
 }
 
 .tooltip {
-    position: absolute;
-    padding: 6px;
-    font-size: 12px;
-    background: rgba(255, 255, 255, 0.9);
-    border: 1px solid #444;
-    border-radius: 4px;
-    white-space: normal;
-    max-width: 400px;
-    pointer-events: none;
-    opacity: 0;
+  position: absolute;
+  padding: 6px;
+  font-size: 12px;
+  background: rgba(255, 255, 255, 0.9);
+  border: 1px solid #444;
+  border-radius: 4px;
+  white-space: normal;
+  max-width: 400px;
+  pointer-events: none;
+  opacity: 0;
+}
+
+/* Warm color harmony for central card */
+:root {
+  --warm-card-bg: #fa920f;
+  --warm-card-text: #ffffff;
+}
+
+#profile .card {
+  background-color: var(--warm-card-bg);
+  border-color: var(--warm-card-bg);
+  color: var(--warm-card-text);
+}
+
+#profile .card .text-muted {
+  color: rgba(255, 255, 255, 0.8) !important;
+}
+
+#profile .card .btn-outline-dark {
+  color: var(--warm-card-text);
+  border-color: var(--warm-card-text);
+}
+
+#profile .card .btn-outline-dark:hover {
+  background-color: var(--warm-card-text);
+  color: var(--warm-card-bg);
 }


### PR DESCRIPTION
## Summary
- Warm profile card background and buttons using magma-inspired palette
- Document profile card color theme in README

## Testing
- `npx prettier --write assets/css/home_style.css`
- `npx prettier --write README.md`
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_68afab7a7d708325aa03dd3fe5320fb5