### PR TITLE
ci: gate deployment on test workflow

### DIFF
--- a/.github/workflows/jekyll2.yml
+++ b/.github/workflows/jekyll2.yml
@@ -7,11 +7,11 @@
 name: Deploy Jekyll site to Pages
 
 on:
-  # Runs on pushes targeting the default branch
-  push:
-    branches: [ "master" ]
-
-  # Allows you to run this workflow manually from the Actions tab
+  workflow_run:
+    workflows: ["Test Jekyll build"]
+    branches: ["master"]
+    types:
+      - completed
   workflow_dispatch:
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
@@ -29,6 +29,7 @@ concurrency:
 jobs:
   # Build job
   build:
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,20 @@
+name: Test Jekyll build
+
+on:
+  push:
+    branches: ["master"]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.1'
+          bundler-cache: true
+      - name: Build site
+        run: bundle exec jekyll build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- CI workflow to verify the Jekyll site builds.
+
+### Changed
+- Deployment workflow runs only after the test workflow succeeds.
+
+## [0.1.0]
+- Initial release.

--- a/README.md
+++ b/README.md
@@ -26,3 +26,13 @@
    ```bash
    bundle exec jekyll serve
    ```
+
+## Tests
+
+Run a local build to verify the site compiles:
+
+```bash
+bundle exec jekyll build
+```
+
+Deployment to GitHub Pages runs only after this check passes on `master`.


### PR DESCRIPTION
## Summary
- ensure GitHub Pages deployment waits for Jekyll build test success
- document dependency of deployment on passing test
- record deployment gating in changelog

## Testing
- `bundle exec jekyll build`


------
https://chatgpt.com/codex/tasks/task_e_68afb80e900c832592c233dc4ffd2a39