### PR TITLE
chore: document serve script

### DIFF
--- a/.github/workflows/serve.yml
+++ b/.github/workflows/serve.yml
@@ -1,0 +1,17 @@
+name: Test serve script
+
+on:
+  push:
+    branches: ["master"]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install Bats
+        run: sudo apt-get update && sudo apt-get install -y bats
+      - name: Run tests
+        run: bats tests/serve.bats

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - CI workflow to verify the Jekyll site builds.
 - Documentation and tests for the Jekyll serve script.
+- CI workflow to test the serve script.
 
 ### Changed
 - Deployment workflow runs only after the test workflow succeeds.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - CI workflow to verify the Jekyll site builds.
+- Documentation and tests for the Jekyll serve script.
 
 ### Changed
 - Deployment workflow runs only after the test workflow succeeds.

--- a/_scripts/serve.sh
+++ b/_scripts/serve.sh
@@ -1,4 +1,23 @@
 #!/usr/bin/env bash
+
+# Serve the Jekyll site locally.
+#
+# Requires:
+#   - bundler
+#   - jekyll
+#
+# Usage:
+#   ./_scripts/serve.sh
+#   JEKYLL_ENV=production ./_scripts/serve.sh
+#
+# Environment variables:
+#   JEKYLL_ENV  Jekyll environment (default: development). The script forwards
+#               this value to Jekyll unchanged.
+#
+# Exit codes:
+#   0   server started successfully
+#   >0  bundler or jekyll returned a non-zero status
+
 set -euo pipefail
 
 bundle exec jekyll serve

--- a/tests/serve.bats
+++ b/tests/serve.bats
@@ -1,0 +1,37 @@
+#!/usr/bin/env bats
+
+setup() {
+	STUB_DIR="$BATS_TEST_DIRNAME/stub"
+	mkdir -p "$STUB_DIR"
+	export PATH="$STUB_DIR:$PATH"
+}
+
+teardown() {
+	rm -rf "$STUB_DIR"
+}
+
+@test "forwards JEKYLL_ENV and arguments" {
+	cat <<'STUB' >"$STUB_DIR/bundle"
+#!/usr/bin/env bash
+echo "args: $*"
+echo "env: $JEKYLL_ENV"
+STUB
+	chmod +x "$STUB_DIR/bundle"
+
+	export JEKYLL_ENV=production
+	run "$BATS_TEST_DIRNAME/../_scripts/serve.sh"
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"args: exec jekyll serve"* ]]
+	[[ "$output" == *"env: production"* ]]
+}
+
+@test "propagates exit status" {
+	cat <<'STUB' >"$STUB_DIR/bundle"
+#!/usr/bin/env bash
+exit 42
+STUB
+	chmod +x "$STUB_DIR/bundle"
+
+	run "$BATS_TEST_DIRNAME/../_scripts/serve.sh"
+	[ "$status" -eq 42 ]
+}


### PR DESCRIPTION
## Summary
- document usage, dependencies, and exit codes for `_scripts/serve.sh`
- add tests confirming `JEKYLL_ENV` forwarding and exit status propagation

## Testing
- `shfmt -w _scripts/serve.sh tests/serve.bats`
- `shellcheck _scripts/serve.sh`
- `bats tests/serve.bats`


------
https://chatgpt.com/codex/tasks/task_e_68b250b851c08325becd39589e2cb84d