### PR TITLE
Add interactive legend to publication graph

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -23,6 +23,7 @@
 
 <div class="container-fluid blur unselectable p-0" id="graph-container">
     <svg></svg>
+    <div id="pub-legend" aria-label="Publication visualization legend"></div>
     <div class="tooltip"></div>
     <script src="assets/js/graph_layout.js"></script>
 </div>

--- a/assets/css/home_style.css
+++ b/assets/css/home_style.css
@@ -4,6 +4,10 @@ svg {
     height: 100vh;
 }
 
+#graph-container {
+    position: relative;
+}
+
 .tooltip {
     position: absolute;
     padding: 6px;
@@ -15,4 +19,92 @@ svg {
     max-width: 400px;
     pointer-events: none;
     opacity: 0;
+    z-index: 600;
+}
+
+#pub-legend {
+    position: absolute;
+    top: 1.5rem;
+    right: 1.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    max-width: min(320px, 35vw);
+    background: rgba(25, 28, 33, 0.85);
+    border-radius: 12px;
+    padding: 1rem 1.25rem;
+    color: #f8f9fa;
+    font-size: 0.875rem;
+    box-shadow: 0 18px 38px rgba(0, 0, 0, 0.45);
+    z-index: 300;
+    backdrop-filter: blur(6px);
+}
+
+#pub-legend svg {
+    display: block;
+    width: 100%;
+}
+
+#pub-legend .legend-section {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+}
+
+#pub-legend .legend-title {
+    font-size: 0.75rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    font-weight: 600;
+    color: rgba(248, 249, 250, 0.85);
+}
+
+#pub-legend .legend-axis text {
+    fill: rgba(248, 249, 250, 0.85);
+    font-size: 0.7rem;
+}
+
+#pub-legend .legend-axis line,
+#pub-legend .legend-axis path {
+    stroke: rgba(248, 249, 250, 0.45);
+}
+
+#pub-legend .legend-citation__label {
+    fill: rgba(248, 249, 250, 0.95);
+}
+
+#pub-legend .legend-citation__swatch {
+    fill: rgba(248, 249, 250, 0.82);
+    stroke: rgba(0, 0, 0, 0.45);
+    stroke-width: 0.5;
+}
+
+@media (max-width: 992px) {
+    #pub-legend {
+        max-width: min(360px, 45vw);
+    }
+}
+
+@media (max-width: 768px) {
+    #pub-legend {
+        top: auto;
+        right: auto;
+        left: 50%;
+        bottom: 1rem;
+        transform: translateX(-50%);
+        max-width: min(420px, 90vw);
+        width: calc(100% - 2rem);
+        align-items: stretch;
+    }
+}
+
+@media (max-width: 576px) {
+    #pub-legend {
+        padding: 0.85rem 1rem;
+        gap: 0.65rem;
+    }
+
+    #pub-legend .legend-title {
+        font-size: 0.7rem;
+    }
 }

--- a/assets/js/graph_layout.js
+++ b/assets/js/graph_layout.js
@@ -1,5 +1,6 @@
 const svg = d3.select("svg");
 const tooltip = d3.select(".tooltip");
+const legendContainer = d3.select("#pub-legend");
 
 d3.json("assets/json/pubs.json").then(data => {
     // Extents
@@ -12,6 +13,90 @@ d3.json("assets/json/pubs.json").then(data => {
     const yScale = d3.scaleLinear().domain(yExtent);
     const rScale = d3.scaleSqrt().domain(rExtent);
     const colorScale = d3.scaleSequential(d3.interpolateMagma).domain(yearExtent);
+
+    const citationMedian = d3.median(data, d => d.num_citations);
+    const citationEntries = [
+        {label: "Min", value: rExtent[0]},
+        {label: "Median", value: citationMedian},
+        {label: "Max", value: rExtent[1]},
+    ].filter(entry => Number.isFinite(entry.value));
+
+    const citationLegendEntries = [];
+    const seenCitationValues = new Set();
+    citationEntries.forEach(entry => {
+        const key = entry.value.toFixed(6);
+        if (!seenCitationValues.has(key)) {
+            seenCitationValues.add(key);
+            citationLegendEntries.push(entry);
+        }
+    });
+    citationLegendEntries.sort((a, b) => a.value - b.value);
+
+    let colorLegendSvg = null;
+    let colorLegendRect = null;
+    let colorLegendAxis = null;
+    let citationLegendSvg = null;
+    const gradientId = "pub-legend-year-gradient";
+    const citationLabelFormatter = d3.format(",");
+
+    if (!legendContainer.empty()) {
+        legendContainer.selectAll("*").remove();
+
+        const colorLegend = legendContainer.append("div")
+            .attr("class", "legend-section legend-section--color");
+        colorLegend.append("span")
+            .attr("class", "legend-title")
+            .text("Publication year");
+
+        colorLegendSvg = colorLegend.append("svg")
+            .attr("class", "legend-colorbar");
+
+        const colorDefs = colorLegendSvg.append("defs");
+        const colorGradient = colorDefs.append("linearGradient")
+            .attr("id", gradientId)
+            .attr("x1", "0%")
+            .attr("x2", "100%")
+            .attr("y1", "0%")
+            .attr("y2", "0%");
+
+        const gradientStops = d3.range(0, 1.01, 0.1);
+        colorGradient.selectAll("stop")
+            .data(gradientStops)
+            .enter()
+            .append("stop")
+            .attr("offset", d => `${(d * 100).toFixed(0)}%`)
+            .attr("stop-color", d => colorScale(yearExtent[0] + d * (yearExtent[1] - yearExtent[0])));
+
+        colorLegendRect = colorLegendSvg.append("rect")
+            .attr("class", "legend-colorbar__swatch")
+            .attr("fill", `url(#${gradientId})`);
+
+        colorLegendAxis = colorLegendSvg.append("g")
+            .attr("class", "legend-axis");
+
+        if (citationLegendEntries.length > 0) {
+            const citationLegend = legendContainer.append("div")
+                .attr("class", "legend-section legend-section--citations");
+            citationLegend.append("span")
+                .attr("class", "legend-title")
+                .text("Citations");
+
+            citationLegendSvg = citationLegend.append("svg")
+                .attr("class", "legend-citations");
+
+            const citationGroups = citationLegendSvg.selectAll("g.legend-citation")
+                .data(citationLegendEntries)
+                .enter()
+                .append("g")
+                .attr("class", "legend-citation");
+
+            citationGroups.append("rect")
+                .attr("class", "legend-citation__swatch");
+
+            citationGroups.append("text")
+                .attr("class", "legend-citation__label");
+        }
+    }
 
     const nodes = data.map((d, i) => ({
         id: i,
@@ -105,6 +190,66 @@ d3.json("assets/json/pubs.json").then(data => {
             .attr("rx", d => d.r)
             .attr("width", d => 2 * d.r)
             .attr("height", d => 2 * d.r);
+
+        if (colorLegendSvg) {
+            const legendWidth = Math.min(320, Math.max(200, width * 0.24));
+            const colorBarHeight = width < 576 ? 12 : 14;
+
+            colorLegendSvg
+                .attr("width", legendWidth)
+                .attr("height", colorBarHeight + 32);
+
+            colorLegendRect
+                .attr("width", legendWidth)
+                .attr("height", colorBarHeight)
+                .attr("rx", 6)
+                .attr("ry", 6);
+
+            const legendYearScale = d3.scaleLinear()
+                .domain(yearExtent)
+                .range([0, legendWidth]);
+
+            const tickCount = width < 576 ? 2 : width < 992 ? 3 : 5;
+
+            colorLegendAxis
+                .attr("transform", `translate(0, ${colorBarHeight + 8})`)
+                .call(
+                    d3.axisBottom(legendYearScale)
+                        .ticks(tickCount)
+                        .tickSize(4)
+                        .tickFormat(d3.format("d"))
+                );
+        }
+
+        if (citationLegendSvg) {
+            const legendWidth = Math.min(320, Math.max(200, width * 0.24));
+            const citationGroups = citationLegendSvg.selectAll("g.legend-citation");
+            const largestRadius = d3.max(citationLegendEntries, d => rScale(d.value)) || 0;
+            const rowHeight = Math.max((largestRadius * 2) + 18, 36);
+
+            citationLegendSvg
+                .attr("width", legendWidth)
+                .attr("height", rowHeight * citationLegendEntries.length);
+
+            citationGroups
+                .attr("transform", (d, i) => `translate(0, ${i * rowHeight})`);
+
+            citationGroups.select("rect")
+                .attr("width", d => 2 * rScale(d.value))
+                .attr("height", d => 2 * rScale(d.value))
+                .attr("rx", d => Math.min(12, rScale(d.value)))
+                .attr("ry", d => Math.min(12, rScale(d.value)));
+
+            citationGroups.select("text")
+                .attr("x", d => (2 * rScale(d.value)) + 12)
+                .attr("y", d => rScale(d.value))
+                .attr("dominant-baseline", "middle")
+                .text(d => {
+                    const count = Math.max(0, Math.round(d.value));
+                    const label = count === 1 ? "citation" : "citations";
+                    return `${d.label}: ${citationLabelFormatter(count)} ${label}`;
+                });
+        }
     }
 
     render();


### PR DESCRIPTION
## Summary
- add a dedicated legend container to the home layout so the visualization can surface publication metadata alongside the graph
- style the legend overlay for desktop and mobile, including spacing, typography, and stacking context tweaks to coexist with tooltips
- populate the legend in the D3 render cycle with a publication year color bar and citation size examples that respond to window resizes

## Testing
- python3 _scripts/build_json.py
- bundle exec jekyll serve

------
https://chatgpt.com/codex/tasks/task_e_68cc5ef5309c8325b28f921c03d32470