### PR TITLE
Scope graph svg selector to prevent oversized colorbar overlay

### DIFF
--- a/assets/css/home_style.css
+++ b/assets/css/home_style.css
@@ -1,5 +1,5 @@
 
-svg {
+#graph-container > svg {
     width: 100%;
     height: 100vh;
 }


### PR DESCRIPTION
## Summary
- limit the full-viewport sizing rule to the main graph svg so the legend svg keeps its intrinsic dimensions

## Testing
- not run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_68cf20ebfdb48325a2d1497097ac9576